### PR TITLE
refactor: replace git-contributors with contributors-from-git

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const gitContributors = require('git-contributors').GitContributors
+const gitContributors = require('contributors-from-git')
 const injectContributors = require('remark-contributors')
 const resolve = require('resolve')
 const heading = require('mdast-util-heading-range')
@@ -45,7 +45,7 @@ module.exports = function attacher (opts) {
       pkg.contributors.forEach(indexContributor.bind(null, indices))
     }
 
-    gitContributors.list(cwd, function (err, contributors) {
+    gitContributors(cwd, function (err, contributors) {
       if (err) {
         if (/does not have any commits yet/.test(err)) {
           file.message('could not get Git contributors as there are no commits yet', null, `${plugin}:no-commits`)

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "index.js"
   ],
   "dependencies": {
+    "contributors-from-git": "^1.0.0",
     "deep-dot": "0.0.2",
-    "git-contributors": "^0.2.3",
     "mdast-util-heading-range": "^2.1.0",
     "parse-author": "^2.0.0",
     "remark-contributors": "^4.0.0",


### PR DESCRIPTION
I forked [`git-contributors`](https://github.com/davidlinse/git-contributors.js) to [`contributors-from-git`](https://github.com/vweevers/contributors-from-git), initially because it was out of date and had a vulnerable dependency (`lodash`), but after refactoring it did not need `lodash` anymore. I intend to keep maintaining `contributors-from-git`.

No functional change, but I did drop node < 6.
